### PR TITLE
BUG: fix missing `self` references

### DIFF
--- a/georules/markov.py
+++ b/georules/markov.py
@@ -41,6 +41,11 @@ class MarkovSequence:
             The initial state use to seed the Markov sequence, by default None. If None,
             the initial state is determined from transition matrix. 
         """
+        # sanity check for user input for init state
+        if init_state is not None and init_state not in self.states: 
+            msg = f"{init_state=} was not found in the knowns states: {self.states=}"
+            raise ValueError(msg)
+        
         # set up the initial probability vector
         if init_state is None: 
             p_vec = self.equilibrium_distribution(self.transition_matrix)


### PR DESCRIPTION
This PR fixes the missing `self` statements that were missing in the `MarkovSequence` class. 

Also adds a check for the `init_state` inside the `get_sequence()` method. 
